### PR TITLE
Fix error when compiling the firmware

### DIFF
--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -19,10 +19,11 @@ def copytree(src, dst, symlinks=False, ignore=None):
 			shutil.copy2(s, d)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
-		if define[0] == field:
-			env['CPPDEFINES'].remove(define)
-	env['CPPDEFINES'].append((field, value))
+    envdefs = env['CPPDEFINES'].copy()
+    for define in envdefs:
+        if define[0] == field:
+            env['CPPDEFINES'].remove(define)
+    env['CPPDEFINES'].append((field, value))
 
 # Relocate the firmware to a new address, such as "0x08005000"
 def relocate_firmware(address):


### PR DESCRIPTION
When trying to compile the firmware in VS Code, the error appears: "RuntimeError: deque mutated during iteration... for define in env[‘CPPDEFINES’]".
A quick Google search shows the [cause](https://community.platformio.org/t/trying-to-compile-marlin-2-1-2-for-ender-3-skr-mini-v2-0-board/33769/11) of this error, as well as the [solution](https://community.platformio.org/t/trying-to-compile-marlin-2-1-2-for-ender-3-skr-mini-v2-0-board/33769/9) to this problem. 
TL;DR: the PlatformIO Core has been updated and the old script no longer works on the updated VS Code. The Marlin developers [fixed](https://github.com/MarlinFirmware/Marlin/commit/c2decc3e2e30c7cb0f517b7e40d8138a8c1d4a81) this at the end of March and my commit is a copy of their fix